### PR TITLE
docs: add LICENSING.md pointer to canonical Lux IP strategy

### DIFF
--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,0 +1,18 @@
+# Licensing
+
+This repository is licensed under the **Lux Ecosystem License v1.2**
+(see [LICENSE](LICENSE)). It belongs to the **patent-protected** tier
+of the Lux three-tier IP strategy.
+
+- Free for **Authorized Networks** (Lux Primary NetID=1, EVM 96369;
+  official testnets/devnets; Descending Chains).
+- Free for **Research Use** (academic, education, evaluation).
+- **Commercial use outside Authorized Networks requires a paid
+  commercial license**.
+
+For the canonical Lux IP and licensing strategy and the precise
+definitions of "Authorized Network", "Descending Chain", and "Research
+Use", see:
+<https://github.com/luxfi/.github/blob/main/profile/README.md>
+
+For commercial licensing inquiries, contact `licensing@lux.network`.


### PR DESCRIPTION
Adds a single LICENSING.md file pointing at the canonical Lux IP and licensing strategy doc on luxfi/.github. LICENSE file unchanged.

Canonical doc: <https://github.com/luxfi/.github/blob/main/profile/README.md>